### PR TITLE
Add hook for default sls offline command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.vscode
 node_modules
 yarn-error.log

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ class ServerlessLocaltunnel {
     }
     // Run tunnels after serverless-offline
     this.hooks = {
-      'before:offline:start:init': this.runServer.bind(this)
+      "before:offline:start": this.runServer.bind(this),
+      "before:offline:start:init": this.runServer.bind(this)
     }
   }
   runTunnel(port, subdomain) {


### PR DESCRIPTION
`sls offline`
`sls offline start`

Are both valid ways to start an offline server. This PR adds an
additional hook to cater for `sls offline` as the start command.

P.S. Thanks for making this thing 🙌 